### PR TITLE
Use SSH flag for cloning UMC, use HTTPS by default

### DIFF
--- a/src/main/java/cam72cam/universalmodcore/Config.java
+++ b/src/main/java/cam72cam/universalmodcore/Config.java
@@ -74,7 +74,7 @@ public class Config {
         }
     }
 
-    public Config(JsonObject data, String loaderBranch) throws GitAPIException, IOException {
+    public Config(JsonObject data, String loaderBranch, boolean useSSH) throws GitAPIException, IOException {
         mod = new Mod(data.get("mod").getAsJsonObject());
         integration = data.has("integration") ? new Integration(data.get("integration").getAsJsonObject()) : null;
         umc = new UMC(data.get("umc").getAsJsonObject());
@@ -100,7 +100,7 @@ public class Config {
             File temp = null;
             if (umc.path == null) {
                 temp = Files.createTempDirectory("umc-loader").toFile();
-                Util.gitClone("https://github.com/TeamOpenIndustry/UniversalModCore.git", loaderBranch, temp, false);
+                Util.gitClone("https://github.com/TeamOpenIndustry/UniversalModCore.git", loaderBranch, temp, useSSH);
                 path = temp;
             } else {
                 path = Paths.get(System.getProperty("user.dir"), umc.path).toFile();

--- a/src/main/java/cam72cam/universalmodcore/Setup.java
+++ b/src/main/java/cam72cam/universalmodcore/Setup.java
@@ -24,7 +24,8 @@ public class Setup {
                 ))
         ).getAsJsonObject();
         String loaderBranch = args[0];
-        Config config = new Config(configObj, loaderBranch);
+        boolean useSSH = args.length >= 2 && args[1].equals("ssh");
+        Config config = new Config(configObj, loaderBranch, useSSH);
 
         ZipInputStream zip = new ZipInputStream(config.openJarStream());
         for (ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()) {
@@ -94,7 +95,7 @@ public class Setup {
                     config.integration.repo,
                     String.format(config.integration.branch, config.minecraftLoader),
                     Paths.get(System.getProperty("user.dir"), config.integration.path).toFile(),
-                    args.length != 2 ? null : !args[1].equals("https")
+                    useSSH
             );
         }
     }


### PR DESCRIPTION
This PR changes two things. Firstly, it clones GIT repositories using HTTPS by default. Secondly, it uses the preferred cloning method when cloning UMC.